### PR TITLE
to avoid NullPointerException with wait object

### DIFF
--- a/src/main/java/com/testvagrant/ekam/atoms/mobile/BaseMobileElement.java
+++ b/src/main/java/com/testvagrant/ekam/atoms/mobile/BaseMobileElement.java
@@ -56,9 +56,9 @@ class BaseMobileElement {
   }
 
   private void init() {
+    this.timeout = Duration.ofSeconds(30);
     this.wait = buildFluentWait(timeout);
     this.touchAction = new TouchAction<>(driver);
-    this.timeout = Duration.ofSeconds(30);
     this.queryFunctions = new QueryFunctions();
   }
 


### PR DESCRIPTION
previously, timeout was null for this.wait = buildFluentWait(timeout);
so, wait.until() was throwing NullPointerException in 
waitUntilTextToBePresent() and waitUntilTextNotToBe(String text, boolean partial) in Element.java